### PR TITLE
Feat: add a list of Custom Sprites for each devices. Add bool 'setNativeSize' in PromptImage

### DIFF
--- a/Runtime/InputSystemActionPrompts/DeviceSpriteSwap.cs
+++ b/Runtime/InputSystemActionPrompts/DeviceSpriteSwap.cs
@@ -1,0 +1,61 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+using UnityEngine.UI;
+
+namespace InputSystemActionPrompts
+{
+    [RequireComponent(typeof(Image))]
+    public class DeviceSpriteSwap : MonoBehaviour
+    {
+
+        /// <summary>
+        /// The image to apply the prompt sprite to
+        /// </summary>
+        private Image m_Image;
+
+        /// <summary>
+        /// The name of the custom sprite to use
+        /// </summary>
+        [SerializeField] private string customSpriteName = "";
+
+        [SerializeField] private bool _setNativeSize = true;
+
+        void Start()
+        {
+            m_Image = GetComponent<Image>();
+            if (m_Image == null) return;
+            RefreshSprite();
+            // Listen to device changing
+            InputDevicePromptSystem.OnActiveDeviceChanged += DeviceChanged;
+        }
+
+        private void OnDestroy()
+        {
+            // Remove listener
+            InputDevicePromptSystem.OnActiveDeviceChanged -= DeviceChanged;
+        }
+
+        /// <summary>
+        /// Called when active input device changed
+        /// </summary>
+        /// <param name="obj"></param>
+        private void DeviceChanged(InputDevice device)
+        {
+            RefreshSprite();
+        }
+
+        /// <summary>
+        /// Sets the icon for the current action
+        /// </summary>
+        private void RefreshSprite()
+        {
+            var sourceSprite = InputDevicePromptSystem.GetDeviceSprite(customSpriteName);
+            if (sourceSprite == null) return;
+
+            m_Image.sprite = sourceSprite;
+            if (_setNativeSize)
+                m_Image.SetNativeSize();
+        }
+
+    }
+}

--- a/Runtime/InputSystemActionPrompts/DeviceSpriteSwap.cs.meta
+++ b/Runtime/InputSystemActionPrompts/DeviceSpriteSwap.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3a25119972e06714c85eecc5a03eb716
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/InputSystemActionPrompts/InputDevicePromptData.cs
+++ b/Runtime/InputSystemActionPrompts/InputDevicePromptData.cs
@@ -24,6 +24,16 @@ namespace InputSystemActionPrompts
       /// </summary>
       public Sprite PromptSprite;
    }
+
+
+    /// <summary>
+    /// Custom sprite entry for when you want to use different image based on the device (e.g. for the controller Image)
+    [Serializable]
+    public class DeviceSpriteEntry
+    {
+        public string SpriteName;
+        public Sprite Sprite;
+    }
    
    /// <summary>
    /// The data for a single input device such as PlayStation 4 Controller
@@ -51,5 +61,9 @@ namespace InputSystemActionPrompts
       /// A list of all the action bindings and their corresponding prompt icons
       /// </summary>
       public List<ActionBindingPromptEntry> ActionBindingPromptEntries;
+      /// <summary>
+      /// A list of optional custom sprites and their corresponding names
+      /// </summary>
+      public List<DeviceSpriteEntry> DeviceSpriteEntries;
    }
 }

--- a/Runtime/InputSystemActionPrompts/InputDevicePromptData.cs
+++ b/Runtime/InputSystemActionPrompts/InputDevicePromptData.cs
@@ -28,6 +28,7 @@ namespace InputSystemActionPrompts
 
     /// <summary>
     /// Custom sprite entry for when you want to use different image based on the device (e.g. for the controller Image)
+    /// </summary>
     [Serializable]
     public class DeviceSpriteEntry
     {

--- a/Runtime/InputSystemActionPrompts/InputDevicePromptSystem.cs
+++ b/Runtime/InputSystemActionPrompts/InputDevicePromptSystem.cs
@@ -159,6 +159,30 @@ namespace InputSystemActionPrompts
         }
 
         /// <summary>
+        /// Gets the current active device matching sprite in DeviceSpriteEntries list for the given sprite name
+        /// </summary>
+        /// <param name="spriteName"></param>
+        /// <returns></returns>
+
+        public static Sprite GetDeviceSprite(string spriteName)
+        {
+            if (!s_Initialised) Initialise();
+            if (s_ActiveDevice == null) return null;
+            var validDevice = s_DeviceDataBindingMap[s_ActiveDevice.name];
+
+            var matchingSprite = validDevice.DeviceSpriteEntries.FirstOrDefault((sprite) =>
+                           String.Equals(sprite.SpriteName, spriteName,
+                                              StringComparison.CurrentCultureIgnoreCase));
+
+            if (matchingSprite != null)
+            {
+                return matchingSprite.Sprite;
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// Creates a TextMeshPro formatted string for all matching sprites for a given tag
         /// Supports composite tags, eg WASD by returning all matches for active device (observing order)
         /// </summary>

--- a/Runtime/InputSystemActionPrompts/PromptIcon.cs
+++ b/Runtime/InputSystemActionPrompts/PromptIcon.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.UI;
 
@@ -16,6 +16,8 @@ namespace InputSystemActionPrompts
         /// The image to apply the prompt sprite to
         /// </summary>
         private Image m_Image;
+
+        [SerializeField] private bool _setNativeSize = true;
         
         void Start()
         {
@@ -47,9 +49,11 @@ namespace InputSystemActionPrompts
         private void RefreshIcon()
         {
             var sourceSprite=InputDevicePromptSystem.GetActionPathBindingSprite(m_Action);
-            m_Image.sprite = sourceSprite;
             if (sourceSprite == null) return;
-            m_Image.SetNativeSize();
+            m_Image.sprite = sourceSprite;
+
+            if (_setNativeSize)
+                m_Image.SetNativeSize();
         }
     }
 }


### PR DESCRIPTION
This will add a list of custom sprites that can be defined for each device. Then each can be called by the entry name with the script 'DeviceSpriteSwap' that will automatically swap an Image based on the connected device. 
This is useful e.g. for a Gamepad image.
This pull request also introduce a bool 'setNativeSize' for PromptIcon. Actually it's always set to native size, which is not always desirable. 
![image](https://github.com/simonoliver/InputSystemActionPrompts/assets/7095376/dcb41f72-a759-4893-b7ad-e1037cee52a9)
![image](https://github.com/simonoliver/InputSystemActionPrompts/assets/7095376/4a91c46c-b1ae-48d8-9e8d-2b6918e86cd7)
