### PR TITLE
Add rich text tags support inside <sprite>

### DIFF
--- a/Runtime/InputSystemActionPrompts/InputDevicePromptSystem.cs
+++ b/Runtime/InputSystemActionPrompts/InputDevicePromptSystem.cs
@@ -215,7 +215,7 @@ namespace InputSystemActionPrompts
             var outputText = string.Empty;
             foreach (var prompt in matchingPrompt)
             {
-                outputText += $"<sprite=\"{validDevice.SpriteAsset.name}\" name=\"{prompt.PromptSprite.name}\">";
+                outputText += $"<sprite=\"{validDevice.SpriteAsset.name}\" name=\"{prompt.PromptSprite.name}\" {s_Settings.RichTextTags}>";
             }
             return outputText;
         }

--- a/Runtime/InputSystemActionPrompts/InputSystemDevicePromptSettings.cs
+++ b/Runtime/InputSystemActionPrompts/InputSystemDevicePromptSettings.cs
@@ -47,6 +47,15 @@ namespace InputSystemActionPrompts
         public string PromptSpriteFormatter = PromptSpriteFormatterSpritePlaceholder;
         
         /// <summary>
+        /// Tags used for custom rich text formatting. 
+        /// </summary>
+        /// <remarks>
+        /// This field can be utilized to define additional rich text tags that can be used in conjunction with the PromptSpriteFormatter.
+        /// </remarks>
+        [Tooltip("Additional rich text tags to be used in conjunction with PromptSpriteFormatter.")]
+        public string RichTextTags = "";
+        
+        /// <summary>
         /// Placeholder used to denote where a sprite should be inserted in the <see cref="InputSystemDevicePromptSettings.PromptSpriteFormatter"/>
         /// </summary>
         public const string PromptSpriteFormatterSpritePlaceholder = "{SPRITE}";


### PR DESCRIPTION
This allows for having custom rich text tags within the <sprite> tag.

In my specific use-case, I need to support recoloring for the input sprites, which can only happen if `tint=1` is added within the sprite tag (i.e.`<sprite="MouseKeyboardDark_Prompts" name="mousekeyboard_key_5" tint=1>`). I'm sure there are probably other cases where this could be useful, too.
This rich text tags are global for the whole project since they live inside the `InputSystemDevicePromptSettings` Scriptable.