### PR TITLE
Add possibility to specify a fixed input settings for platforms.

### DIFF
--- a/Runtime/InputSystemActionPrompts/InputDevicePromptSystem.cs
+++ b/Runtime/InputSystemActionPrompts/InputDevicePromptSystem.cs
@@ -444,7 +444,7 @@ namespace InputSystemActionPrompts
                         //Debug.Log($"Binding {bindingPathLower} to path {binding.path}");
                         var entry = new ActionBindingMapEntry
                         {
-                            BindingPath = binding.path,
+                            BindingPath = binding.effectivePath,
                             IsComposite = binding.isComposite,
                             IsPartOfComposite = binding.isPartOfComposite
                         };

--- a/Runtime/InputSystemActionPrompts/InputSystemDevicePromptSettings.cs
+++ b/Runtime/InputSystemActionPrompts/InputSystemDevicePromptSettings.cs
@@ -71,5 +71,16 @@ namespace InputSystemActionPrompts
             return settings;
         }
 
+        [Space]
+        [Tooltip("Optional overrides for platform specific device prompts. Instead of being dynamic, on these platform will be used only the specified input settings.")]
+        public List<PlatformInputOverride> RuntimePlatformsOverride = new List<PlatformInputOverride>();
+
+        [System.Serializable]
+        public class PlatformInputOverride
+        {
+            public RuntimePlatform Platform;
+            public InputDevicePromptData DevicePromptData;
+        }
+
     }
 }


### PR DESCRIPTION
_**The issue:**_ 
On certain platforms you don't need to dynamically retrieve the current input device (as for example on console you can only play with the default controller), is far more convenient to specify a fixed input configuration. This will also remove the needs to having to specify all the possible input devices name

**_How is being solved:_**
A new section under the input device prompt settings allow to specify the default input data for a given runtime platform
![image](https://github.com/user-attachments/assets/fbc5d781-52c5-4ff5-98a0-96bcdd30716b). 
When the InputSystemActionPrompts is initialized, will fetch the application platform, and will use the specified config if match any entry in the RuntimePlatformOverride section.
