### PR TITLE
Update InputSystemDevicePromptSettingsHelper.cs to create folder if it does not exist

### DIFF
--- a/Editor/InputSystemDevicePromptSettingsHelper.cs
+++ b/Editor/InputSystemDevicePromptSettingsHelper.cs
@@ -12,6 +12,14 @@ namespace InputSystemActionPrompts.Editor
         [MenuItem("Window/Input System Action Prompts/Create Settings")]
         public static void CreateSettings()
         {
+            // Ensure the Resources folder exists
+            string resourcesPath = "Assets/Resources";
+            if (!AssetDatabase.IsValidFolder(resourcesPath))
+            {
+                System.IO.Directory.CreateDirectory(resourcesPath);
+                AssetDatabase.Refresh();
+            }
+            
             var settings = ScriptableObject.CreateInstance<InputSystemDevicePromptSettings>();
             // Initialise with all input action assets found in project and packages
             settings.InputActionAssets = GetAllInstances<InputActionAsset>().ToList();
@@ -25,7 +33,8 @@ namespace InputSystemActionPrompts.Editor
             };
             settings.OpenTag = '[';
             settings.CloseTag = ']';
-            AssetDatabase.CreateAsset(settings, $"Assets/Resources/{InputSystemDevicePromptSettings.SettingsDataFile}.asset");
+            string assetPath = $"{resourcesPath}/{InputSystemDevicePromptSettings.SettingsDataFile}.asset";
+            AssetDatabase.CreateAsset(settings, assetPath);
             AssetDatabase.SaveAssets();
         }
         


### PR DESCRIPTION
## What changed?
- Check if `Asset/Resources` exists. If it does not: create a new folder

## Motive
Whenever I make a new project this makes me annoyed because I always forget to make the Resource folder

## Testing
Ran it locally, System.IO is cross-platform so this should work across any OS.